### PR TITLE
Check if PID pointed to by PID file is alive

### DIFF
--- a/bin/registry-static
+++ b/bin/registry-static
@@ -54,12 +54,23 @@ process.on('SIGINT', function() {
     process.exit();
 });
 
-if (fs.existsSync(pidFile)) {
+try {
+    // Check if PID the PID file points to is still alive.
+    // If this throws, the file doesn't exist and we're fine.
+    var pid = parseInt(fs.readFileSync(pidFile, 'utf8'), 10);
+
+    // If this throws, the process doesn't exist.
+    process.kill(pid, 0);
+
+    // We're here because neither `fs.readFileSync` nor `process.kill` threw.
+    // We have a PID file pointing to an alive process. Bail out.
     console.error('\n\n--------------------------------');
-    console.error('Found a pid file, is another process running?');
+    console.error('Found a pid file, process with PID ' + pid + ' is still running');
     console.error(pidFile);
     console.error('--------------------------------\n\n');
     process.exit(1);
+}
+catch (er) {
 }
 
 process.on('SIGHUP', function() {


### PR DESCRIPTION
Avoid situations like loss of power where the PID file doesn't get
removed and `registry-static` refuses to start because of a leftover
PID file.
