### PR TITLE
skip bad JSON from follow-registry

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,7 +70,17 @@ var updateIndex = function(data, callback) {
 //This pauses the feed until callback is executed
 var change = function(data, callback) {
     var changeStart = new Date();
-    var json = patch.json(data.json, options.domain);
+    var json;
+    try {
+        json = patch.json(data.json, options.domain);
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            //Bad json. Just bail.
+            return callback();
+        } else {
+            throw e;
+        }
+    }
     if (!json.name) {
         //Bail, something is wrong with this change
         return callback();


### PR DESCRIPTION
Takes care of #11

`patch-package-json` *should* throw a SyntaxError when you feed it bad JSON, so this wraps that and ignores SyntaxErrors.