### PR TITLE
use abstract-blob-store/fs-blob-store

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,14 @@ Here are the currently provided hooks:
 
 Some examples are included in the `examples` directory.
 
+BLOB-STORES
+-----------
+
+By default, `registry-static` uses `fs-blob-store`, meaning all the metadata and tarballs are stored
+on disk, wherever you've decided to with the `--dir` option. Alternatively, you can use a custom
+blob store, as long as it implements the [abstract-blob-store](https://github.com/maxogden/abstract-blob-store)
+spec. Just create a file that exports the blob store you want, and then pass that in to the `--blobstore` option.
+
 LOGGING
 -------
 

--- a/lib/args.js
+++ b/lib/args.js
@@ -106,6 +106,12 @@ if (!options.version && !options.help && !options.restart) {
     }
 } //otherwise we're not actually running, so don't bother with the checks
 
+if (options.blobstore) {
+    options.blobstore = require(options.blobstore);
+} else {
+    options.blobstore = require('fs-blob-store')(options.dir);
+}
+
 if (options.hooks) {
     //Not wrapping this, if it throws, it throws..
     options.hooks = require(options.hooks);

--- a/lib/files.js
+++ b/lib/files.js
@@ -4,29 +4,31 @@ Code licensed under the BSD License.
 See LICENSE file.
 */
 var async = require('async');
-var fs = require('graceful-fs');
-var mkdirp = require('mkdirp');
 var path = require('path');
 var options = require('./args.js');
 var log = require('davlog');
 var verify = require('./verify.js');
 var hooks = require('./hooks');
 
+function writeJSONFile(name, data, callback) {
+    process.nextTick(function(){
+        var stream = options.blobstore.createWriteStream(name, callback);
+        stream.write(JSON.stringify(data, null, 4) + '\n');
+        stream.end();
+    });
+}
+
 var putBall = function(info, callback) {
-    info.tarball = path.join(options.dir, info.path);
+    info.tarball = path.join(info.path);
 
     hooks.tarball(info, callback, function () {
         process.nextTick(function() {
-            mkdirp(path.dirname(info.tarball), function() {
-                process.nextTick(function() {
-                    verify.verify(info, function (err) {
-                        if (err) {
-                            return callback(err);
-                        }
+            verify.verify(info, function (err) {
+                if (err) {
+                    return callback(err);
+                }
 
-                        hooks.afterTarball(info, callback, callback);
-                    });
-                });
+                hooks.afterTarball(info, callback, callback);
             });
         });
     });
@@ -46,14 +48,7 @@ var putPart = function(info, callback) {
         return callback();
     }
     hooks.versionJson(info, callback, function() {
-        var file = path.join(options.dir, info.json.name, info.version, 'index.json');
-        process.nextTick(function() {
-            mkdirp(path.dirname(file), function() {
-                process.nextTick(function() {
-                    fs.writeFile(file, JSON.stringify(info.json, null, 4) + '\n', callback);
-                });
-            });
-        });
+        writeJSONFile(path.join(info.json.name, info.version, 'index.json'), info.json, callback);
     });
 };
 
@@ -72,22 +67,16 @@ var putJSON = function(info, callback) {
     var seq = info.seq;
     var latestSeq = info.latestSeq;
     hooks.indexJson(info, putAllParts, function() {
-        var file = path.join(options.dir, doc.name, 'index.json');
+        var file = path.join(doc.name, 'index.json');
         log.info('[' + seq + '/' + latestSeq + ']', 'writing json for', doc.name, 'to', file);
-        process.nextTick(function() {
-            mkdirp(path.dirname(file), function() {
-                process.nextTick(function() {
-                    fs.writeFile(file, JSON.stringify(doc, null, 4) + '\n', function(err) {
-                        if (err) {
-                            return putJSON(info, callback);
-                        }
-                        if (!info.versions || !info.versions.length) {
-                            return callback();
-                        }
-                        process.nextTick(putAllParts);
-                    });
-                });
-            });
+        writeJSONFile(file, doc, function(err) {
+            if (err) {
+                return putJSON(info, callback);
+            }
+            if (!info.versions || !info.versions.length) {
+                return callback();
+            }
+            process.nextTick(putAllParts);
         });
     });
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,9 +6,7 @@ See LICENSE file.
 var follow = require('follow-registry');
 var patch = require('patch-package-json');
 var files = require('./files.js');
-var path = require('path');
 var fs = require('graceful-fs');
-var mkdirp = require('mkdirp');
 var timethat = require('timethat').calc;
 var http = require('http-https');
 var url = require('url');
@@ -23,10 +21,34 @@ var log = require('davlog');
 var options = require('./args');
 var version = require('../package.json').version;
 
+function readFile(name, cb){
+    var result = '';
+    var errored = false;
+    return options.blobstore.createReadStream(name)
+    .on('error', function(err){
+        errored = true;
+        cb(err);
+    })
+    .on('data', function(data){
+        result += data.toString();
+    })
+    .on('end', function(){
+        if (errored){
+            return;
+        }
+        cb(null, result);
+    });
+}
+
+function writeFile(name, data, cb) {
+    var writeStream = options.blobstore.createWriteStream(name, cb);
+    writeStream.write(data);
+    writeStream.end();
+}
+
 var updateIndex = function(data, callback) {
     hooks.globalIndexJson(data, callback, function() {
-        var index = path.join(options.dir, 'index.json');
-        fs.readFile(index, 'utf8', function(err, d) {
+        readFile('index.json', function(err, d) {
             var json;
             try {
                 //sometimes the json can get corrupted or missing, this catches that
@@ -58,7 +80,7 @@ var updateIndex = function(data, callback) {
                 o[key] = json[key];
             });
             json = o;
-            return fs.writeFile(index, JSON.stringify(json, null, 4) + '\n', 'utf8', callback);
+            return writeFile('index.json', JSON.stringify(json, null, 4) + '\n', callback);
         });
     });
 };
@@ -115,27 +137,27 @@ var change = function(data, callback) {
 };
 exports.change = change;
 
-var defaults = function(callback) {
-    mkdirp(options.dir, function() {
-        var error = fs.createWriteStream(path.join(options.dir, '404.json'));
-        log.info('Writing 404.json');
-        fs.createReadStream(options.error)
-            .on('end', function() {
-                var indexOut = path.join(options.dir, 'index.json');
-                fs.exists(indexOut, function(good) {
-                    if (good) {
-                        log.info('skipping index.json since it exists');
-                        return callback();
-                    }
-                    var index = fs.createWriteStream(indexOut);
-                    log.info('Writing index.json');
-                    fs.createReadStream(options.index)
-                        .on('end', callback)
-                        .pipe(index);
-                });
-            })
-            .pipe(error);
+var defaults = function(opts, callback) {
+    if (!callback && typeof opts === 'function') { // for testing
+        callback = opts;
+        opts = options;
+    }
+    var error = opts.blobstore.createWriteStream('404.json', function(err){
+        opts.blobstore.exists('index.json', function(err, good) {
+            if (err) {
+                return callback(err);
+            }
+            if (good) {
+                log.info('skipping index.json since it exists');
+                return callback(err);
+            }
+            var index = opts.blobstore.createWriteStream('index.json', callback);
+            log.info('Writing index.json');
+            fs.createReadStream(opts.index).on('error', callback).pipe(index);
+        });
     });
+    log.info('Writing 404.json');
+    fs.createReadStream(opts.error).on('error', callback).pipe(error);
 };
 exports.defaults = defaults;
 

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -3,13 +3,9 @@ Copyright (c) 2014, Yahoo! Inc. All rights reserved.
 Code licensed under the BSD License.
 See LICENSE file.
 */
-var fs = require('fs'),
-    http = require('http-https'),
-    path = require('path'),
+var http = require('http-https'),
     options = require('./args'),
     crypto = require('crypto'),
- 
-    mkdirp = require('mkdirp'),
     timethat = require('timethat').calc,
     url = require('url'),
     uparse = url.parse,
@@ -30,56 +26,54 @@ exports.counter = function() {
 
 var update = function(info, callback) {
     var url = options.registry + info.path.substring(1);
-    mkdirp(path.dirname(info.tarball), function() {
-        var callbackDone = false;
-        process.nextTick(function() {
-            var writer = fs.createWriteStream(info.tarball);
-            counter[info.path] = counter[info.path] || 0;
-            counter[info.path]++;
-            log.info('[' + counter[info.path] + '] downloading', url);
-            var startDL = new Date();
-            var u = uparse(url);
-            u.headers = {
-                'user-agent': 'registry static mirror worker'
-            };
-            var req = http.get(u)
-                .on('error', function(e) {
-                    callbackDone = true;
-                    req.end();
-                    log.err(' [' + counter[info.path] + '] failed to download', info.tarball);
-                    report.error = e;
-                    report[info.tarball] = info;
-                    delete counter[info.path];
-                    //in case end has already been called by the error handler
-                    //sometimes it happens :(
-                    try {
-                        writer.end();
-                    } catch (er) {}
-                    return callback(new Error('failed to download ' + info.tarball));
-                })
-                .on('response', function(res) {
-                    log.info('[' + counter[info.path] + ']', '(' + res.statusCode + ')', info.path, 'is', pretty(res.headers['content-length']));
-                    info.http = res.statusCode;
-                    if (res.statusCode === 404) {
-                        log.err(' [' + counter[info.path] + '] failed to download with a 404', info.tarball);
-                        callbackDone = true;
-                        report[info.tarball] = info;
-                        delete counter[info.path];
-                        writer.end();
-                        req.abort();
-                        return callback(new Error('failed to download ' + info.tarball));
-                    }
-                    res.on('end', function() {
-                        if (callbackDone) {
-                            return;
-                        }
-                        log.info('[' + counter[info.path] + '] finished downloading', url, 'in', timethat(startDL));
-                        process.nextTick(function() {
-                            exports.verify(info, callback);
-                        });
-                    })
-                        .pipe(writer);
+    var callbackDone = false;
+    process.nextTick(function() {
+        var writer = options.blobstore.createWriteStream(info.tarball);
+        counter[info.path] = counter[info.path] || 0;
+        counter[info.path]++;
+        log.info('[' + counter[info.path] + '] downloading', url);
+        var startDL = new Date();
+        var u = uparse(url);
+        u.headers = {
+            'user-agent': 'registry static mirror worker'
+        };
+        var req = http.get(u)
+        .on('error', function(e) {
+            callbackDone = true;
+            req.end();
+            log.err(' [' + counter[info.path] + '] failed to download', info.tarball);
+            report.error = e;
+            report[info.tarball] = info;
+            delete counter[info.path];
+            //in case end has already been called by the error handler
+            //sometimes it happens :(
+            try {
+                writer.end();
+            } catch (er) {}
+            return callback(new Error('failed to download ' + info.tarball));
+        })
+        .on('response', function(res) {
+            log.info('[' + counter[info.path] + ']', '(' + res.statusCode + ')', info.path, 'is', pretty(res.headers['content-length']));
+            info.http = res.statusCode;
+            if (res.statusCode === 404) {
+                log.err(' [' + counter[info.path] + '] failed to download with a 404', info.tarball);
+                callbackDone = true;
+                report[info.tarball] = info;
+                delete counter[info.path];
+                writer.end();
+                req.abort();
+                return callback(new Error('failed to download ' + info.tarball));
+            }
+            res.on('end', function() {
+                if (callbackDone) {
+                    return;
+                }
+                log.info('[' + counter[info.path] + '] finished downloading', url, 'in', timethat(startDL));
+                process.nextTick(function() {
+                    exports.verify(info, callback);
                 });
+            })
+            .pipe(writer);
         });
     });
 };
@@ -89,7 +83,7 @@ exports.update = update;
 var verify = function(info, callback) {
     counter[info.path] = counter[info.path] || 0;
     process.nextTick(function() {
-        fs.exists(info.tarball, function(good) {
+        options.blobstore.exists(info.tarball, function(err, good) {
             if (!good) {
                 return exports.update(info, callback);
             }
@@ -104,7 +98,7 @@ var verify = function(info, callback) {
             process.nextTick(function() {
                 var shasum = crypto.createHash('sha1');
                 shasum.setEncoding('hex');
-                fs.createReadStream(info.tarball)
+                options.blobstore.createReadStream(info.tarball)
                     .on('end', function() {
                         shasum.end();
                         var d = shasum.read();

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "davlog": "~0.1.0",
     "event-stream": "^3.1.5",
     "follow-registry": "~0.0.3",
+    "fs-blob-store": "^5.1.1",
     "graceful-fs": "^2.0.3",
     "http-https": "^1.0.0",
     "mkdirp": "~0.4.0",
@@ -25,6 +26,7 @@
     "yargs": "^1.3.3"
   },
   "devDependencies": {
+    "abstract-blob-store": "^3.2.0",
     "istanbul": "~0.3.5",
     "jshint": "^2.5.1",
     "marked-man": "^0.1.4",

--- a/tests/args.js
+++ b/tests/args.js
@@ -7,6 +7,9 @@ mockery.registerMock('davlog', {
     err: function() {
     }
 });
+mockery.registerMock('fs-blob-store', function(x){
+    return x;
+});
 
 mockery.enable({
     useCleanCache: true,


### PR DESCRIPTION
This sends all data that would be going directly to the filesystem for
mirring purposes through `options.blobstore` instead, which is
`fs-blob-store` by default.

Not all FS opertions have been replaced with blob-store operations. For
example, config files, tmpfiles, index and error files are all accessed using
`fs`.

The `--blobstore` option is added, which provides a file to be required
that exports a blob-store.

Closes #26