### PR TITLE
don't break on versions without a name

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -62,6 +62,12 @@ var putJSON = function(info, callback) {
         if (err) {
             return callback(err);
         }
+        info.versions.forEach(function(item, key) {
+            if (item.json) {
+                item.json.name = item.json.name || doc.name;
+                info.versions[key] = item;
+            }
+        });
         async.eachLimit(info.versions, 5, putPart, callback);
     };
     var seq = info.seq;


### PR DESCRIPTION
A module was published yesterday that caused the mirroring to stop working:

http://registry.npmjs.org/zachtestproject2

The meta-data in this module is crap, it's almost non-existent. We are checking for the `name` on the `version` of the module and it's not even in this blob of data. So I had to add this little hack to get around it. It's not pretty, but it allowed my replicators to start working again.