### PR TITLE
replace domain field for one,sync commands

### DIFF
--- a/lib/one.js
+++ b/lib/one.js
@@ -1,6 +1,8 @@
 var request = require('request');
 var url = require('url');
+var patch = require('patch-package-json');
 var files = require('./files');
+var options = require('./args');
 
 module.exports = function one(name, cb){
     request.get('https://registry.npmjs.org/'+name, {json: true}, function(err, res, body){
@@ -22,6 +24,7 @@ module.exports = function one(name, cb){
                 });
             }
             Object.keys(body.versions).forEach(function(ver){
+                body.versions[ver] = patch.json(body.versions[ver], options.domain);
                 data.versions.push({version: ver, json: body.versions[ver]});
                 data.tarballs.push({
                     path: url.parse(body.versions[ver].dist.tarball).path,

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -3,8 +3,10 @@ var fs = require('graceful-fs'),
     log = require('davlog'),
     request = require('request'),
     check = require('./util').check,
+    options = require('./args'),
     timer = require('timethat').calc,
-    async = require('async');
+    async = require('async'),
+    patch = require('patch-package-json');
 
 
 var sync = function(options) {
@@ -42,6 +44,11 @@ var sync = function(options) {
                     return callback(null, null);
                 }
                 log.warn(json.name, 'is out of sync, saving new index');
+                if (body.versions) {
+                    Object.keys(body.versions).forEach(function (ver) {
+                        body.versions[ver] = patch.json(body.versions[ver], options.domain);
+                    });
+                }
                 fs.writeFile(base, JSON.stringify(body, null, 4), 'utf8', function() {
                     check(body, options, callback);
                 });

--- a/tests/one.js
+++ b/tests/one.js
@@ -14,13 +14,13 @@ var goodBody = {
     versions: {
         '1': {
             dist: {
-                tarball: 'https://registry.npmjs.org/foo/1.tgz',
+                tarball: 'http://example.com/foo/1.tgz',
                 shasum: '123abc'
             }
         },
         '2': {
             dist: {
-                tarball: 'https://registry.npmjs.org/foo/2.tgz',
+                tarball: 'http://example.com/foo/2.tgz',
                 shasum: '456def'
             }
         }
@@ -33,13 +33,13 @@ var goodBodyNoTags = {
     versions: {
         '1': {
             dist: {
-                tarball: 'https://registry.npmjs.org/foo/1.tgz',
+                tarball: 'http://example.com/foo/1.tgz',
                 shasum: '123abc'
             }
         },
         '2': {
             dist: {
-                tarball: 'https://registry.npmjs.org/foo/2.tgz',
+                tarball: 'http://example.com/foo/2.tgz',
                 shasum: '456def'
             }
         }
@@ -72,6 +72,9 @@ var tests = {
                 cb();
             }
         });
+        mockery.registerMock('./args', {
+            domain: 'example.com'
+        });
         mockery.enable({
             useCleanCache: true,
             warnOnReplace: false,
@@ -97,8 +100,8 @@ var tests = {
         },
         'saves tarballs': function(d){
             assert.deepEqual(d[0], [
-                {path: '/foo/1.tgz', tarball: 'https://registry.npmjs.org/foo/1.tgz', shasum: '123abc'},
-                {path: '/foo/2.tgz', tarball: 'https://registry.npmjs.org/foo/2.tgz', shasum: '456def'}
+                {path: '/foo/1.tgz', tarball: 'http://example.com/foo/1.tgz', shasum: '123abc'},
+                {path: '/foo/2.tgz', tarball: 'http://example.com/foo/2.tgz', shasum: '456def'}
             ]);
         },
         'saves json': function(d){
@@ -111,8 +114,8 @@ var tests = {
                     {version: '2', json: goodBody.versions['2']}
                 ],
                 tarballs: [
-                    {path: '/foo/1.tgz', tarball: 'https://registry.npmjs.org/foo/1.tgz', shasum: '123abc'},
-                    {path: '/foo/2.tgz', tarball: 'https://registry.npmjs.org/foo/2.tgz', shasum: '456def'}
+                    {path: '/foo/1.tgz', tarball: 'http://example.com/foo/1.tgz', shasum: '123abc'},
+                    {path: '/foo/2.tgz', tarball: 'http://example.com/foo/2.tgz', shasum: '456def'}
                 ]
             });
         }
@@ -127,8 +130,8 @@ var tests = {
         },
         'saves tarballs': function(d){
             assert.deepEqual(d[0], [
-                {path: '/foo/1.tgz', tarball: 'https://registry.npmjs.org/foo/1.tgz', shasum: '123abc'},
-                {path: '/foo/2.tgz', tarball: 'https://registry.npmjs.org/foo/2.tgz', shasum: '456def'}
+                {path: '/foo/1.tgz', tarball: 'http://example.com/foo/1.tgz', shasum: '123abc'},
+                {path: '/foo/2.tgz', tarball: 'http://example.com/foo/2.tgz', shasum: '456def'}
             ]);
         },
         'saves json': function(d){
@@ -139,8 +142,8 @@ var tests = {
                     {version: '2', json: goodBodyNoTags.versions['2']}
                 ],
                 tarballs: [
-                    {path: '/foo/1.tgz', tarball: 'https://registry.npmjs.org/foo/1.tgz', shasum: '123abc'},
-                    {path: '/foo/2.tgz', tarball: 'https://registry.npmjs.org/foo/2.tgz', shasum: '456def'}
+                    {path: '/foo/1.tgz', tarball: 'http://example.com/foo/1.tgz', shasum: '123abc'},
+                    {path: '/foo/2.tgz', tarball: 'http://example.com/foo/2.tgz', shasum: '456def'}
                 ]
             });
         }


### PR DESCRIPTION
In the case of sync and one options, tarball field at index.json is not replaced in spite of specifying the domain.Please check it, and tell me if I have a misunderstanding of the specification.
