### PR TITLE
one process

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,15 +113,6 @@ up to 4 times. If it fails all of those, it is skipped and not stored locally.
 Each `change` request will process the entire module, not just the change alone. This is to make sure that tags
 and new versions are all in sync.
 
-AUTOMATION
-----------
-
-The main process always writes a `pid` file: `$TMPDIR/registry-static.pid`
-If you use the `--restart` option, it will send a `SIGHUP` to the registered process found in the `pid` file. 
-It will then restart the child process.
-
-This way you can add a crontab entry to force a restart so you don't have to monitor the process all the time.
-
 HOOKS
 -----
 
@@ -168,7 +159,7 @@ Here are the currently provided hooks:
 * **`versionJson`**: Called before writing the `index.json` for a particular package version.
 * **`tarball`**: Called before downloading/verifying/writing a package tarball.
 * **`afterTarball`**: Called after downloading/verifying/writing a package tarball. If there is no error, the callback parameters are ignored.
-* **`startup`**: Called in parent process before spawning the child (worker) process.
+* **`startup`**: Called before doing anything else at start time.
 
 Some examples are included in the `examples` directory.
 
@@ -185,12 +176,12 @@ LOGGING
 
 Supports `--log <path>` to log all output to a specific file.
 
-When doing this, you may want to rotate your logs. You can do this by sending the main 
+When doing this, you may want to rotate your logs. You can do this by sending the 
 process a `SIGPIPE` signal. This will free up the file descriptor and then reattach it to the file.
 
-If you are using logrotate.d, here is a sample command:
+If you are using logrotate.d, configure your process monitor to start `registry-static` like this:
 
-`registry-static -d my.registry.com -o /var/www/ --tmp /tmp/ --log /var/log/registry-static/output.log`
+`registry-static -d my.registry.com -o /var/www/ --log /var/log/registry-static/output.log`
 
 
 and the logrotate config file (/etc/logrotate.d/registry-static):
@@ -208,6 +199,7 @@ and the logrotate config file (/etc/logrotate.d/registry-static):
             endscript
     }
 
+(This assumes that your process monitor stores the pid in `/tmp/registry-static.pid`.)
 
 CAVEATS
 -------

--- a/bin/registry-static
+++ b/bin/registry-static
@@ -23,8 +23,6 @@ logger();
 
 var log = require('davlog');
 
-var pidFile = path.join(options.tmp, 'registry-static.pid');
-
 if (options.sync) {
     return require('../lib/sync')(options);
 }
@@ -43,134 +41,8 @@ if (options.replport) {
     require('../lib/repl')();
 }
 
-if (options.restart) {
-    var pid = fs.readFileSync(pidFile, 'utf8');
-    log.info('\n\n--------------------------------');
-    log.info('Restarting process', pid);
-    log.info('--------------------------------\n\n');
-    process.kill(pid, 'SIGHUP');
-    return;
-}
-
-var child;
-
-process.on('SIGPIPE', function() {
-    //pass SIGPIPE to the child for log rotation
-    process.kill(child.pid, 'SIGPIPE');
+hooks.startup({}, function(){}, function(){
+    require('../lib/index').start();
 });
 
-process.on('SIGINT', function() {
-    log.info('Cleaning up pidfile');
-    fs.unlinkSync(pidFile);
-    process.exit();
-});
 
-try {
-    // Check if PID the PID file points to is still alive.
-    // If this throws, the file doesn't exist and we're fine.
-    var pid = parseInt(fs.readFileSync(pidFile, 'utf8'), 10);
-
-    // If this throws, the process doesn't exist.
-    process.kill(pid, 0);
-
-    // We're here because neither `fs.readFileSync` nor `process.kill` threw.
-    // We have a PID file pointing to an alive process. Bail out.
-    console.error('\n\n--------------------------------');
-    console.error('Found a pid file, process with PID ' + pid + ' is still running');
-    console.error(pidFile);
-    console.error('--------------------------------\n\n');
-    process.exit(1);
-}
-catch (er) {
-}
-
-process.on('SIGHUP', function() {
-    log.info('\n\n--------------------------------');
-    log.info('SIGHUP received, restarting child process (' + child.pid + ')');
-    log.info('--------------------------------\n\n');
-    child.stdout.unpipe(logger.writer);
-    process.kill(child.pid, 'SIGKILL');
-});
-
-fs.writeFileSync(pidFile, process.pid, 'utf8');
-
-argv.unshift(path.join(__dirname, '../lib/background.js'));
-log.info('\n\n--------------------------------');
-log.info('starting background task..');
-log.info('--------------------------------\n\n');
-var proc = 0;
-var run = function(c) {
-    if (c) {
-        //Only count the respawn if there is an exit code
-        proc++;
-    }
-    if (proc >= options.spawn) {
-        log.info('\n\n--------------------------------');
-        log.info('spawn cap', options.spawn, 'hit, bailing..');
-        log.info('--------------------------------\n\n');
-        process.nextTick(function(){ // allow log to catch up
-            process.exit(1);
-        });
-    }
-    hooks.startup({
-        spawnCount: proc,
-        exitCode: c
-    }, function(){
-        log.info('\n\n--------------------------------');
-        log.info('spawn blocked by "startup" hook, bailing...');
-        log.info('--------------------------------\n\n');
-        process.nextTick(function(){ // allow log to catch up
-            process.exit(1);
-        });
-    }, function () {
-        process.env.PROC_SPAWN = proc;
-        process.env.PARENT_PID = process.pid;
-        child = exec(process.execPath, argv, {
-            cwd: process.cwd(),
-            env: process.env,
-            stdio: [process.stdin, 'pipe', 'pipe']
-        });
-        var a = [];
-        var sinceAdded, lastWasLog;
-        argv.forEach(function(item) {
-            if (lastWasLog) {
-                lastWasLog = false;
-                return;
-            }
-            switch (item) {
-                case '--log':
-                    lastWasLog = true;
-                    break;
-                case '--clean':
-                    break;
-                case '--since':
-                    sinceAdded = true;
-                    break;
-                default:
-                    if (sinceAdded) {
-                        sinceAdded = null;
-                        break;
-                    }
-                    a.push(item);
-                    break;
-            }
-        });
-        argv = a;
-
-        child.on('close', function(code) {
-            if (code >= 250) {
-                //Internal error..
-                process.exit(1);
-            }
-            log.info('\n\n--------------------------------');
-            log.info('subprocess exited with code', code, 'restarting process..');
-            log.info('--------------------------------\n\n');
-            run(code);
-        });
-
-        child.stdout.pipe(logger.writer);
-    });
-};
-
-//Start the script in a child process, restarting on error..
-run();

--- a/lib/args.js
+++ b/lib/args.js
@@ -31,7 +31,6 @@ options.describe('domain', 'The domain replacer                                 
 options.describe('dir', 'The output directory                                [required]');
 options.describe('registry', 'The registry to mirror from');
 options.describe('limit', 'Limit the number of concurrent downloads');
-options.describe('spawn', 'The number of times a spawn happens before the process exits');
 options.describe('user', 'Set the user that this process should change to');
 options.describe('group', 'Set the group that this process should change to');
 options.describe('hooks', 'Provide a hooks module.');
@@ -39,10 +38,8 @@ options.describe('clean', 'Clear the sequance file');
 options.describe('check', 'Crawl the tarballs and check all of their shasums');
 options.describe('sync', 'Crawl the json files and look for outdated index files');
 options.describe('report', 'Used with --check, write a json report for all missing files');
-options.describe('restart', 'Restart the child process, in case it is stuck');
 options.describe('log', 'The file to log the output to');
 options.describe('quiet', 'Turn down the logger');
-options.describe('tmp', 'Directory to store the pid file in (i.e. $TMPDIR)');
 options.describe('index', 'An index.json for the whole registry');
 options.describe('error', 'A 404 file');
 options.describe('replport', 'Port to listen on for REPL');
@@ -80,7 +77,7 @@ options = options.argv;
 if (options.version) {
     var version = require('../package.json').version;
     console.log(version);
-    process.exit(250);
+    process.exit(1);
 }
 
 //This one isn't configurable.
@@ -99,11 +96,11 @@ if (options.group) {
 if (!options.version && !options.help && !options.restart) {
     if (!options.domain && !options.check) {
         log.err('Domain rewrite url not provided, try --help');
-        process.exit(250);
+        process.exit(1);
     }
     if (!options.dir) {
         log.err('Output directory not found, try --help');
-        process.exit(250);
+        process.exit(1);
     }
 } //otherwise we're not actually running, so don't bother with the checks
 

--- a/lib/check.js
+++ b/lib/check.js
@@ -29,7 +29,7 @@ exports.check = check;
 
 /*istanbul ignore next we know process.exit works*/
 var exit = function() {
-    process.exit(250);
+    process.exit(1);
 };
 exports.exit = exit;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,6 @@ var updateIndex = function(data, callback) {
             //This is for nagios checking..
             json.couchdb = 'Welcome';
             json.pid = process.pid;
-            json.parentPid = Number(process.env.PARENT_PID);
             json.version = version;
             json.dir = options.dir;
             json.uptime = timethat(new Date(), new Date(Date.now() + (process.uptime() * 1000)));
@@ -213,7 +212,7 @@ var run = function() {
         handler: change,
         logger: log
     };
-    log.info('[' + process.env.PROC_SPAWN + '] starting to follow registry with these options:');
+    log.info('starting to follow registry with these options:');
     log.info('   domain', options.domain);
     log.info('   directory', options.dir);
     log.info('   tmp', options.tmp);

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -3,25 +3,14 @@ var repl = require("repl");
 var fs = require('fs');
 var path = require('path');
 var logger = require('./logger');
+var log = require('davlog');
 var options = require('./args');
 var one = require('./one');
 
-function bounce() {
-    var pidFile = path.join(options.tmp, 'registry-static.pid');
-    var self = this;
-    fs.readFile(pidFile, 'utf8', function(err, pid){
-        self.outputStream.write('Restarting process: '+pid+'\n');
-        process.kill(pid, 'SIGHUP');
-        self.displayPrompt();
-    });
-}
-
-var bounceDef = {
-    help: 'bounce the child process',
-    action: bounce
-};
+var pipedStreams = [];
 
 function liveLog() {
+    pipedStreams.push(this.outputStream);
     logger.writer.pipe(this.outputStream);
 }
 
@@ -32,20 +21,35 @@ var logDef = {
 
 module.exports = function () {
     net.createServer(function (socket) {
+        var thisOutputStream;
         socket.write('\n.help for help\n');
+        socket.on('error', function(e){
+            log.info('repl client has disconnected');
+            if (thisOutputStream) {
+                logger.writer.unpipe(thisOutputStream);
+            }
+        });
         var telnetRepl = repl.start({
             prompt: "registry-static > ",
             input: socket,
             output: socket,
 
         }).on('exit', function() {
+            log.info('repl client has disconnected');
+            if (thisOutputStream) {
+                logger.writer.unpipe(thisOutputStream);
+            }
             socket.end();
         });
 
         // defineCommand gives us .commands
-        telnetRepl.defineCommand('restart', bounceDef);
-        telnetRepl.defineCommand('bounce', bounceDef);
-        telnetRepl.defineCommand('log', logDef);
+        telnetRepl.defineCommand('log', {
+            help: 'live logs',
+            action: function liveLog() {
+                thisOutputStream = this.outputStream;
+                logger.writer.pipe(this.outputStream);
+            }
+        });
         telnetRepl.context.one = function(name) {
             one(name, function(err) {
                 if (err) {

--- a/tests/args.js
+++ b/tests/args.js
@@ -46,7 +46,7 @@ var tests = {
         },
         'and error': function(d) {
             assert.ok(d);
-            assert.equal(d, 250);
+            assert.equal(d, 1);
         }
     },
     'process valid args': {


### PR DESCRIPTION
This removes the parent-child process scheme that was used for process monitoring. Registry-static isn't the the business of being a process-monitoring tool, not should it be, so this commit removes all that in favor of using well-used monitoring tools like `monit`, `god`, `upstart`, `systemd`, etc.

As an added bonus, random stream errors are less likely to happen, and the whole thing is easier to maintain.

This is pretty major, and we end up losing a bunch of things like:

* The `spawn`, `tmp`, `restart` options.
* `pid` files.

This isn't really a huge deal, since these are basically the job of process monitoring tools anyway.

If/When this is merged, I'd go for a major release, since this removes that functionality.