### PR TITLE
fix to resolve the tarball's path for verify func

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -14,7 +14,7 @@ var check = function(o, options, callback) {
             var u = url.parse(info.dist.tarball);
             tarballs.push({
                 path: u.pathname,
-                tarball: path.join(options.dir, u.pathname),
+                tarball: path.join(u.pathname),
                 shasum: info.dist.shasum
             });
         }

--- a/tests/util.js
+++ b/tests/util.js
@@ -58,10 +58,10 @@ var tests = {
         'tarballs verified': function(d) {
             assert(d[0].verified);
             assert.equal(d[0].path, '/foo/1/foo-1.tgz');
-            assert.equal(d[0].tarball, '/mirror/foo/1/foo-1.tgz');
+            assert.equal(d[0].tarball, '/foo/1/foo-1.tgz');
             assert(d[1].verified);
             assert.equal(d[1].path, '/foo/2/foo-2.tgz');
-            assert.equal(d[1].tarball, '/mirror/foo/2/foo-2.tgz');
+            assert.equal(d[1].tarball, '/foo/2/foo-2.tgz');
         },
         'early exit (versions)': {
             topic: function() {


### PR DESCRIPTION
From https://github.com/davglass/registry-static/pull/29, the resolution of the tarball's path which is passed to verify function has changed for bs-blob-store interface.So ```lib/util``` also should be fixed like ```lib/files```. 
https://github.com/davglass/registry-static/pull/29/files#diff-5f0f864ee8d5579cbdf6172d403f223bL16.