### PR TITLE
new hook: shasumCheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Here are the currently provided hooks:
 * **`tarball`**: Called before downloading/verifying/writing a package tarball.
 * **`afterTarball`**: Called after downloading/verifying/writing a package tarball. If there is no error, the callback parameters are ignored.
 * **`startup`**: Called before doing anything else at start time.
+* **`shasumCheck`**: Called in order to check the `sha1sum` of a tarball. Calling back with true implies the shasum passed. Default is in `lib/defaultShasumCheck.js`.
 
 Some examples are included in the `examples` directory.
 

--- a/lib/defaultShasumCheck.js
+++ b/lib/defaultShasumCheck.js
@@ -1,0 +1,33 @@
+var crypto = require('crypto');
+
+module.exports = function (info, callback) {
+    var options = this.options;
+    var log = this.log;
+    var shasum = crypto.createHash('sha1');
+    shasum.setEncoding('hex');
+    options.blobstore.createReadStream(info.tarball)
+    .on('error', function(e) {
+        // There are some totally crap situations where the tarball
+        // path is something silly, like a directory, but still a
+        // path on the filesystem, so `exists` passes. Ignore and continue.
+        log.err('failed to read from path which supposedly exists:', info.path);
+        log.err(e.stack);
+        callback(null, true);
+    })
+    .on('end', function() {
+        shasum.end();
+        var d = shasum.read();
+        if (info.shasum !== d) {
+            info.error = {
+                found: d,
+                expected: info.shasum
+            };
+            log.err('shasum check failed for', info.path);
+            log.err('found', d, 'expected', info.shasum);
+            return callback();
+        }
+        log.info('shasum check passed for', info.path, '(' + info.shasum + ')');
+        callback(null, true);
+    })
+    .pipe(shasum);
+};

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -3,7 +3,7 @@ Copyright (c) 2014, Yahoo! Inc. All rights reserved.
 Code licensed under the BSD License.
 See LICENSE file.
 */
-var options = require('./args.js');
+var options = require('./args');
 var log = require('davlog');
 var hooks = options.hooks;
 
@@ -18,8 +18,12 @@ function defaultHook(data, callback, success) {
 }
 
 function wrap(hookName) {
+    return wrapHook(hooks[hookName]);
+}
+
+function wrapHook(hook) {
     return function wrapped(data, callback, success){
-        hooks[hookName].call(hookContext, data, function(err, good) {
+        hook.call(hookContext, data, function(err, good) {
             if (err) {
                 return callback(err);
             }
@@ -39,3 +43,4 @@ exports.versionJson = hooks.hasOwnProperty('versionJson') ? wrap('versionJson') 
 exports.indexJson = hooks.hasOwnProperty('indexJson') ? wrap('indexJson') : defaultHook;
 exports.globalIndexJson = hooks.hasOwnProperty('globalIndexJson') ? wrap('globalIndexJson') : defaultHook;
 exports.startup = hooks.hasOwnProperty('startup') ? wrap('startup') : defaultHook;
+exports.shasumCheck = hooks.hasOwnProperty('shasumCheck') ? wrap('shasumCheck') : wrapHook(require('./defaultShasumCheck'));

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -5,6 +5,7 @@ See LICENSE file.
 */
 var http = require('http-https'),
     options = require('./args'),
+    hooks = require('./hooks'),
     crypto = require('crypto'),
     timethat = require('timethat').calc,
     url = require('url'),
@@ -96,35 +97,15 @@ var verify = function(info, callback) {
             }
             log.info('[' + counter[info.path] + '] checking shasum of', info.tarball);
             process.nextTick(function() {
-                var shasum = crypto.createHash('sha1');
-                shasum.setEncoding('hex');
-                options.blobstore.createReadStream(info.tarball)
-                    .on('error', function(e) {
-                        // There are some totally crap situations where the tarball
-                        // path is something silly, like a directory, but still a
-                        // path on the filesystem, so `exists` passes. Ignore and continue.
-                        log.err(' [' + counter[info.path] + '] failed to read from path which supposedly exists:', info.path);
-                        log.err(e.stack);
-                        callback(null, info);
-                    })
-                    .on('end', function() {
-                        shasum.end();
-                        var d = shasum.read();
-                        if (info.shasum !== d) {
-                            info.error = {
-                                found: d,
-                                expected: info.shasum
-                            };
-                            log.err(' [' + counter[info.path] + '] shasum check failed for', info.path);
-                            log.err(' [' + counter[info.path] + '] found', d, 'expected', info.shasum);
-                            return exports.update(info, callback);
-                        }
-                        log.info('[' + counter[info.path] + '] shasum check passed for', info.path, '(' + info.shasum + ')');
-                        delete counter[info.path];
-                        callback(null, info);
-                    })
-                    .pipe(shasum);
+                hooks.shasumCheck(info, function(){
+                    // shasum failed
+                    exports.update(info, callback);
+                }, function(){
+                    // shasum passed
+                    delete counter[info.path];
+                    callback(null, info);
                 });
+            });
         });
     });
 };

--- a/tests/hooks.js
+++ b/tests/hooks.js
@@ -12,7 +12,8 @@ var hookNames = [
     'versionJson',
     'indexJson',
     'globalIndexJson',
-    'startup'
+    'startup',
+    'shasumCheck'
 ];
 var testError = new Error();
 
@@ -25,8 +26,11 @@ function getHooks(overrides) {
         });
     }
     options.hooks = optHooks;
-    mockery.registerMock('./args.js', options);
+    mockery.registerMock('./args', options);
     mockery.registerMock('davlog', davlog);
+    mockery.registerMock('./defaultShasumCheck', function(data, callback){
+        callback(null, true);
+    });
     mockery.enable({
         useCleanCache: true,
         warnOnReplace: false,

--- a/tests/verify.js
+++ b/tests/verify.js
@@ -44,6 +44,7 @@ describe('verify', function(){
             get registry() {
                 return badRegistry ? 'http://fhgidygfi' : 'http://registry.npmjs.org';
             },
+            hooks: {},
             blobstore: memblob
         });
         mockery.registerMock('davlog', {
@@ -193,8 +194,8 @@ describe('verify', function(){
                 assert.ifError(err);
                 assert(info.updateCalled);
                 assert.deepEqual(log, [
-                        ' [0] shasum check failed for /the/path/4',
-                        ' [0] found 3da541559918a808c2402bba5012f6c60b27661c expected badHash'
+                        'shasum check failed for /the/path/4',
+                        'found 3da541559918a808c2402bba5012f6c60b27661c expected badHash'
                 ]);
                 done();
             });


### PR DESCRIPTION
Unlike other hooks, this one replaces a chunk of functionality. This is
to allow for use-cases where a straight-up shasum check from the
blobstore/filesystem isn't what we want to do. This can also be used to
bypass the shasum check entirely, for non-mirroring use-cases.