### PR TITLE
deal w/ index.json collision (and 404.json)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Since we are writing a bunch of `index.json` files, you need to setup `nginx` to
     myregistry.com/foo
                     /index.json
 
+Note also that we write `404.json` and the top-level `index.json` to the '-' directory under the root, in order to not
+collide with packages that might have those names.
+
 Here is the simple `nginx.config` that I use on my local mirror.
 
     server {
@@ -84,17 +87,17 @@ Here is the simple `nginx.config` that I use on my local mirror.
         }
 
         #don't cache the main index
-        location /index.json {
+        location /-/index.json {
             expires -1;
         }
 
         #cache all json by modified time
         location / {
             expires modified +15m;
-            try_files $uri $uri/index.json $uri.json =404;
+            try_files $uri $uri/-/index.json $uri/index.json $uri.json =404;
         }
 
-        error_page  404              /404.json;
+        error_page  404              /-/404.json;
     }
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,9 @@ var log = require('davlog');
 var options = require('./args');
 var version = require('../package.json').version;
 
+var GLOBAL_INDEX = '-/index.json';
+var NOT_FOUND = '-/404.json';
+
 function readFile(name, cb){
     var result = '';
     var errored = false;
@@ -53,7 +56,7 @@ function writeFile(name, data, cb) {
 
 var updateIndex = function(data, callback) {
     hooks.globalIndexJson(data, callback, function() {
-        readFile('index.json', function(err, d) {
+        readFile(GLOBAL_INDEX, function(err, d) {
             var json;
             try {
                 //sometimes the json can get corrupted or missing, this catches that
@@ -84,7 +87,7 @@ var updateIndex = function(data, callback) {
                 o[key] = json[key];
             });
             json = o;
-            return writeFile('index.json', JSON.stringify(json, null, 4) + '\n', callback);
+            return writeFile(GLOBAL_INDEX, JSON.stringify(json, null, 4) + '\n', callback);
         });
     });
 };
@@ -148,8 +151,8 @@ var defaults = function(opts, callback) {
         callback = opts;
         opts = options;
     }
-    var error = opts.blobstore.createWriteStream('404.json', function(err){
-        opts.blobstore.exists('index.json', function(err, good) {
+    var error = opts.blobstore.createWriteStream(NOT_FOUND, function(err){
+        opts.blobstore.exists(GLOBAL_INDEX, function(err, good) {
             if (err) {
                 return callback(err);
             }
@@ -157,7 +160,7 @@ var defaults = function(opts, callback) {
                 log.info('skipping index.json since it exists');
                 return callback(err);
             }
-            var index = opts.blobstore.createWriteStream('index.json', callback);
+            var index = opts.blobstore.createWriteStream(GLOBAL_INDEX, callback);
             log.info('Writing index.json');
             fs.createReadStream(opts.index).on('error', callback).pipe(index);
         });

--- a/tests/index.js
+++ b/tests/index.js
@@ -176,7 +176,7 @@ describe('index', function(){
                 name: 'foo'
             }
         }, function() {
-            var result = JSON.parse(memblob.data['index.json']);
+            var result = JSON.parse(memblob.data['-/index.json']);
             memblob.data = {};
             assert.equal(result.couchdb, 'Welcome');
             assert.equal(result.processing, 'foo');
@@ -196,7 +196,7 @@ describe('index', function(){
                 return done(err);
             }
             skipped.push(data);
-            opts.blobstore.data = {'index.json': 'asdf'};
+            opts.blobstore.data = {'-/index.json': 'asdf'};
             index.defaults(opts, function(err, data){
                 if (err) {
                     return done(err);
@@ -217,7 +217,7 @@ describe('index', function(){
             },
             versions: ['']
         }, function() {
-            var d = JSON.parse(memblob.data['index.json']);
+            var d = JSON.parse(memblob.data['-/index.json']);
 
             assert.equal(d.couchdb, 'Welcome');
             assert.equal(d.processing, 'bar');


### PR DESCRIPTION
Fixes #43 

I'm not entirely sure I've done the nginx config correctly, so any extra attention to that would be appreciated.

This fix isn't self-correcting, in that it won't deal well with existing `index.json` shenanigans. The easiest thing to do is shut down your running `registry-static`, delete the `404.json` and `index.json` at the root, knock back your sequence file to before the `index.json` problem (if you care about the package with that name), and then upgrade and restart.