### PR TITLE
return early when latest tag doesn't exist

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -157,6 +157,9 @@ function checkForScopedDependencies(data, callback) {
             json = ver.json;
         }
     });
+    if (!json) {
+        return callback();
+    }
     [
         'dependencies',
         'devDependencies',


### PR DESCRIPTION
When checking through dependencies for scoped modules, sometimes a
module has a dist-tag that isn't in that module's set of versions. This
is bad data, but we need to deal with it. When this happens, just keep
on truckin'.