### PR TITLE
expose webapp to startup hook

### DIFF
--- a/bin/registry-static
+++ b/bin/registry-static
@@ -12,6 +12,8 @@ var options = require('../lib/args');
 var hooks = require('../lib/hooks');
 var fs = require('fs');
 
+var webapp;
+
 if (options.help || options.version) {
     require('../lib/index');
     return;
@@ -37,10 +39,10 @@ if (options.replport) {
     require('../lib/repl')();
 }
 if (options.httpport) {
-    require('../lib/http')();
+    webapp = require('../lib/http')();
 }
 
-hooks.startup({}, function(){}, function(){
+hooks.startup({webapp: webapp}, function(){}, function(){
     require('../lib/index').start();
 });
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -22,5 +22,6 @@ app.get('/syncone.json', function syncone(req, res) {
 });
 
 module.exports = function repl() {
-    return app.listen(options.httpport);
+    app.listen(options.httpport);
+    return app;
 };


### PR DESCRIPTION
The express webapp that runs on `httpport` is now available in the data
object passed to the `startup` hook. This is useful for attaching other
endpoints to the express app. For example, you may have metrics specific
to your use-case that you want to expose.