### PR TITLE
handle bad json files where info.json.name is not a string

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -82,7 +82,7 @@ exports.saveTarballs = saveTarballs;
 
 //Always write it even if it is there.
 function putPart (info, callback) {
-    if (!info.json) {
+    if (!info.json || (info.json && (typeof info.json.name !== 'string'))) {
         return callback();
     }
     hooks.versionJson(info, callback, function() {


### PR DESCRIPTION
There's a few bad packages in npm where the `info.json.name` field is not a string, but a nested object.

Under those cases `path.join()` throws an exception and the replication process crashes.

This guard allows the process to gracefully continue.