### PR TITLE
https for default registry

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -65,7 +65,7 @@ options.alias('version', 'v');
 //Defaults
 options.default('spawn', 20);
 options.default('limit', 10);
-options.default('registry', 'http://registry.npmjs.org/');
+options.default('registry', 'https://registry.npmjs.org/');
 options.default('tmp', os.tmpdir());
 options.default('index', path.join(__dirname, '../defaults', 'index.json'));
 options.default('error', path.join(__dirname, '../defaults', '404.json'));


### PR DESCRIPTION
The registry.npmjs.org has changed recently to return 301 redirects for non-HTTPS requests. The tarball download (lib/verify.js) neither follows redirects nor bails on zero-byte response.